### PR TITLE
Feat: Trust Domain URI parsing, complete rest of trust domain methods

### DIFF
--- a/src/spiffeid/id.zig
+++ b/src/spiffeid/id.zig
@@ -1,6 +1,5 @@
 pub const std = @import("std");
-
-pub const uriProtocol = "spiffe://";
+const uriProtocol = @import("protocol.zig").uriProtocol;
 
 pub const InvalidSpiffeID = error{
     EmptySpiffeID,
@@ -75,7 +74,7 @@ test "Parse an empty string as SpiffeID, it should error" {
 }
 
 test "Parse an incomplete string as SpiffeID, it should error" {
-    _ = ID.from_string("spiffe://") catch |err| {
+    _ = ID.from_string(uriProtocol) catch |err| {
         try std.testing.expect(err == InvalidSpiffeID.MissingTrustDomain);
     };
 }

--- a/src/spiffeid/id.zig
+++ b/src/spiffeid/id.zig
@@ -1,5 +1,5 @@
 pub const std = @import("std");
-const uriProtocol = @import("protocol.zig").uriProtocol;
+const uriScheme = @import("protocol.zig").uriScheme;
 
 pub const InvalidSpiffeID = error{
     EmptySpiffeID,
@@ -25,8 +25,8 @@ pub const ID = struct {
     // into a SpiffeID.
     pub fn from_string(str: []const u8) InvalidSpiffeID!ID {
         if (str.len == 0) return error.EmptySpiffeID;
-        if (str.len < uriProtocol.len) return error.MissingPrefix;
-        if (!std.mem.eql(u8, uriProtocol, str[0..9])) return error.MissingPrefix;
+        if (str.len < uriScheme.len) return error.MissingPrefix;
+        if (!std.mem.eql(u8, uriScheme, str[0..9])) return error.MissingPrefix;
 
         const stripped = str[9..];
         if (stripped.len == 0) return error.MissingTrustDomain;
@@ -41,7 +41,7 @@ pub const ID = struct {
         self: ID,
         alc: std.mem.Allocator,
     ) ![]const u8 {
-        return std.fmt.allocPrint(alc, "{s}{s}/{s}", .{ uriProtocol, self.trust_domain, self.path });
+        return std.fmt.allocPrint(alc, "{s}{s}/{s}", .{ uriScheme, self.trust_domain, self.path });
     }
 
     // The maximum size of a SPIFFE ID is 2048 bytes, which would be nice to represent with an unsigned 11-bit integer.
@@ -49,7 +49,7 @@ pub const ID = struct {
     pub fn size(self: ID) u64 {
         // include the separating '/' between trust_domain and path and return a
         // usize so this can safely be used for buffer sizing without truncation.
-        return uriProtocol.len + self.trust_domain.len + 1 + self.path.len;
+        return uriScheme.len + self.trust_domain.len + 1 + self.path.len;
     }
 };
 
@@ -74,7 +74,7 @@ test "Parse an empty string as SpiffeID, it should error" {
 }
 
 test "Parse an incomplete string as SpiffeID, it should error" {
-    _ = ID.from_string(uriProtocol) catch |err| {
+    _ = ID.from_string(uriScheme) catch |err| {
         try std.testing.expect(err == InvalidSpiffeID.MissingTrustDomain);
     };
 }

--- a/src/spiffeid/protocol.zig
+++ b/src/spiffeid/protocol.zig
@@ -1,0 +1,2 @@
+/// URI protocol constant for SPIFFE IDs and trust domains.
+pub const uriProtocol = "spiffe://";

--- a/src/spiffeid/protocol.zig
+++ b/src/spiffeid/protocol.zig
@@ -1,2 +1,5 @@
+/// URI scheme constant for SPIFFE IDs and trust domains.
+pub const uriScheme = "spiffe://";
+
 /// URI protocol constant for SPIFFE IDs and trust domains.
-pub const uriProtocol = "spiffe://";
+pub const uriProtocol = uriScheme[0..6];

--- a/src/spiffeid/root.zig
+++ b/src/spiffeid/root.zig
@@ -1,5 +1,10 @@
 //! This module provides types and functions for managing SPIFFE IDs.
 
 const id = @import("id.zig");
+const td = @import("td.zig");
 
 pub const ID = id.ID;
+pub const TrustDomain = td.TrustDomain;
+
+pub const RequireTrustDomainFromString = td.RequireTrustDomainFromString;
+pub const RequireTrustDomainFromUri = td.RequireTrustDomainFromUri;

--- a/src/spiffeid/td.zig
+++ b/src/spiffeid/td.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const iddef = @import("./id.zig");
 const uriScheme = @import("./protocol.zig").uriScheme;
 const uriProtocol = @import("./protocol.zig").uriProtocol;
 const testing = std.testing;
@@ -19,6 +20,10 @@ pub const TrustDomain = struct {
         @memcpy(result[uriScheme.len..], self.td);
 
         return result;
+    }
+
+    pub fn id(self: TrustDomain) iddef.ID {
+        return iddef.ID.new(self.td, "");
     }
 
     pub fn name(self: TrustDomain) []const u8 {
@@ -182,4 +187,11 @@ test "It should parse a valid URI as a SPIFFE trust domain" {
     const id = try td.idString(testing.allocator);
     try testing.expect(std.mem.eql(u8, id, "spiffe://example.org"));
     testing.allocator.free(id);
+}
+
+test "It should return the ID type when the TD is populated" {
+    const td = try TrustDomainFromString("spiffe://example.org");
+    const id = td.id();
+    try testing.expect(std.mem.eql(u8, id.trust_domain, "example.org"));
+    try testing.expect(std.mem.eql(u8, id.path, ""));
 }


### PR DESCRIPTION
This PR makes a number of changes:
- Implement code review feedback from @Coutlaw in https://github.com/tjons/ziffe/pull/5 by:
  - adding a well-known constant representing the `spiffe` protocol and the `spiffe://` URI scheme, 
  - refactoring the `spiffeid.TrustDomain` validation code to use `switch() {}`
- Add new features to support generating `spiffeid.TrustDomain` structs from `std.Uri`.
- Complete the rest of the necessary methods to provide effective parity with the Go SDK for `spiffeid.TrustDomain`.

After merging this PR, the `spiffeid.TrustDomain` type can be considered reasonably complete. 